### PR TITLE
Remove vestigial switch_mode function

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,10 +1,7 @@
 "use strict";
 var database = new MapperDatabase();
 
-var view;                       // holds the current view object
-var viewIndex;                  // index of current view
-var viewData = new Array(3);    // data specific to the view, change 3 the number of views
-
+var view;
 var mapProperties;
 var devFilter;
 var saverLoader;
@@ -66,7 +63,11 @@ function init() {
         function() {
             switch (index) {
             case 0:
-                switch_mode('new');
+                $('#container').empty();
+                view = new ViewManager(document.getElementById('container'), database);
+                view.init();
+                view.on_resize();
+                mapProperties.clearMapProperties();
                 command.start();
                 command.send('refresh');
                 command.send('get_networks');
@@ -377,46 +378,6 @@ function initMapPropertiesCommands()
 function refresh_all() {
     database.clearAll();
     command.send('refresh');
-}
-
-/**
- * Called by the view selector to change the current view
- */
-function switch_mode(newMode)
-{
-    if (view) {
-        // save view settings
-        if (typeof view.save_view_settings == 'function')
-            viewData[viewIndex] = view.save_view_settings();
-        
-        // tell the view to cleanup (ex: removing event listeners)
-        view.cleanup();
-    }
-    
-    $('#container').empty();
-    switch (newMode) {
-        case 'classic':
-            view = new listView(database);
-            viewIndex = 0;
-            view.init();
-            break;
-        case 'new':
-            view = new ViewManager(document.getElementById('container'), database);
-            viewIndex = 3;
-            view.init();
-            view.on_resize();
-            break;
-        default:
-            //console.log(newMode);
-    }
-
-//    // load view settings (if any)
-//    if (viewData[viewIndex]) {
-//        if (typeof view.load_view_settings == 'function')
-//            view.load_view_settings(viewData[viewIndex]);
-//    }
-
-    mapProperties.clearMapProperties();
 }
 
 function select_obj(obj) {


### PR DESCRIPTION
If I'm not mistaken, it appears that the switch_mode function in main.js is only used once during the init function. It is never called in a situation where view would evaluate true, nor is it ever called with an argument other than 'new'. It seems that we should be able to get rid of switch_mode entirely and simply do what it does in init, which is much clearer imo.

Similarly, the viewIndex and viewData vars are only used in the switch_mode function in circumstances that never come to pass, so they can also be deleted.

I'm assuming these things are all leftovers from a time when they had a purpose, but now that they don't seem to anymore I would advocate getting rid of them since they are a bit confusing to a newcomer (such as myself).

Unless I am mistaken of course, in which case I would be glad to learn how these things are used since I can't seem to figure it out.