### PR TITLE
Fix Resizing

### DIFF
--- a/js/SignalTable.js
+++ b/js/SignalTable.js
@@ -93,7 +93,7 @@ class SignalTable {
             angle_was += Math.PI * 2;
 
         $({someValue: 0}).animate({someValue: 1},
-                                  {duration: duration * 0.33,
+                                  {duration: duration,
                                   step: function(now, fx) {
             let was = 1 - now;
             self.frame.left = left * now + left_was * was;
@@ -113,14 +113,13 @@ class SignalTable {
                 'text-align': self.frame.angle ? 'right' : 'left'
             });
 
-            if (innerLeft != null && innerWidth != null) {
-                $('#' + self.id + 'Scroller').css({
-                    'left': innerLeft ? innerLeft : 0,
-                    'top': 0,
-                    'width': innerWidth ? innerWidth : '100%',
-                    'height': self.frame.height - 20,
-                });
-            }
+            $('#' + self.id + 'Scroller').css({
+                'left': innerLeft ? innerLeft : 0,
+                'top': 0,
+                'width': innerWidth ? innerWidth : '100%',
+                'height': self.frame.height - 20,
+            });
+
             if (func)
                 func();
         }});

--- a/js/views/BalloonView.js
+++ b/js/views/BalloonView.js
@@ -67,8 +67,8 @@ class BalloonView extends View {
             remove_node_svg(root.children[i]);  // recurse
     }
 
-    resize(newFrame) {
-        super.resize(newFrame);
+    _resize(duration) {
+        super._resize(newFrame);
 
         let path = circle_path(this.frame.left + this.frame.width * 0.33, this.frame.cy, 0);
         path.push(circle_path(this.frame.left + this.frame.width * 0.67, this.frame.cy, 0));

--- a/js/views/CanvasView.js
+++ b/js/views/CanvasView.js
@@ -35,10 +35,7 @@ class CanvasView extends View {
         this.resize(null, 1000);
     }
 
-    resize(newFrame, duration) {
-        if (newFrame)
-            this.frame = newFrame;
-
+    _resize(duration) {
         let self = this;
         this.tables.left.adjust(0, 0, this.leftExpandWidth, this.frame.height,
                                 0, duration, function() {self.draw()}, 0, 0);

--- a/js/views/ChordView.js
+++ b/js/views/ChordView.js
@@ -54,10 +54,7 @@ class ChordView extends View {
         this.resize();
     }
 
-    resize(newFrame, duration) {
-        if (newFrame)
-            this.frame = newFrame;
-
+    _resize(duration) {
         this.mapPane.left = 0;
         this.mapPane.width = this.frame.width;
         this.mapPane.top = 0;
@@ -238,10 +235,9 @@ class ChordView extends View {
         if (!dev.view)
             return;
         dev.view.stop();
-        let staged = false;
-        let r = dev.view.radius;
+        let offline = (dev.status == 'offline');
         let angleInc;
-        if (dev.status == 'offline') {
+        if (offline == 'offline') {
             if (dev.draggingFrom)
                 angleInc = self.onlineInc;
             else
@@ -251,10 +247,23 @@ class ChordView extends View {
             angleInc = self.onlineInc;
         }
 
-        dev.view.path = [['M', dev.view.pstart.x, dev.view.pstart.y],
+        let r = self.radius ? self.radius : 0;
+        let cx = self.mapPane.cx;
+        let cy = self.mapPane.cy;
+        let x = cx * (offline ? 1.5 : 0.5);
+        let angle = (dev.index - 0.45) * angleInc;
+        let pstart = {'angle': angle,
+                      'x': x + Math.cos(angle) * r,
+                      'y': cy + Math.sin(angle) * r};
+        angle += angleInc * 0.9;
+        let pstop = {'angle': angle,
+                     'x': x + Math.cos(angle) * r,
+                     'y': cy + Math.sin(angle) * r};
+
+        dev.view.path = [['M', pstart.x, pstart.y],
                          ['A', r, r, angleInc,
                           fuzzyEq(angleInc, 6.283, 0.01) ? 1 : 0, 1,
-                          dev.view.pstop.x, dev.view.pstop.y]];
+                          pstop.x, pstop.y]];
         dev.view.attr({'stroke-linecap': 'butt'})
                 .animate({'path': dev.view.path,
                           'fill-opacity': 0,

--- a/js/views/ConsoleView.js
+++ b/js/views/ConsoleView.js
@@ -290,11 +290,7 @@ class ConsoleView extends View {
         this.resize(null, 1000);
     }
 
-    resize(newFrame, duration) {
-        if (newFrame)
-            this.frame = newFrame;
-
-        let self = this;
+    _resize(duration) {
         this.mapPane.left = 0;
         this.mapPane.width = this.frame.width;
         this.mapPane.height = this.frame.height;

--- a/js/views/GraphView.js
+++ b/js/views/GraphView.js
@@ -29,15 +29,16 @@ class GraphView extends View {
         this.resize();
     }
 
-    resize(newFrame) {
-        super.resize(newFrame);
+    _resize(duration) {
+        super._resize();
         $('#axes').stop(true, false)
                   .text('foooooo')
                   .css({'left': this.frame.left + 50,
                         'top': this.frame.top + 50,
                         'width': this.frame.width - 100,
                         'height': this.frame.height - 100,
-                        'opacity': 1});
+                        'opacity': 1,
+                        'z-index': -1});
     }
 
     update() {

--- a/js/views/GridView.js
+++ b/js/views/GridView.js
@@ -41,8 +41,6 @@ class GridView extends View {
         this.pan = this.tablePan;
         this.zoom = this.tableZoom;
 
-        this.leftExpandWidth = 200;
-        this.rightExpandWidth = 200;
 
         this.tables.left.collapseHandler = function() {
             if (self.tables.left.expandWidth != self.leftExpandWidth) {
@@ -60,16 +58,15 @@ class GridView extends View {
         };
 
         this.update();
+        this.leftExpandWidth = 200;
+        this.rightExpandWidth = 200;
         this.resize(null, 1000);
 
         // move svg canvas to front
         $('#svgDiv').css({'position': 'relative', 'z-index': 2});
     }
 
-    resize(newFrame, duration) {
-        if (newFrame)
-            this.frame = newFrame;
-
+    _resize(duration) {
         let self = this;
         this.tables.left.adjust(0, this.rightExpandWidth-20, this.leftExpandWidth,
                                 this.frame.height - this.rightExpandWidth + 20,
@@ -89,15 +86,9 @@ class GridView extends View {
         this.mapPane.cy = this.mapPane.top + this.mapPane.height * 0.5;
 
         $('#svgDiv').css({'left': this.mapPane.left,
-                          'top': this.mapPane.top,
-                          'width': this.mapPane.width,
-                          'height': this.mapPane.height});
+                          'top': this.mapPane.top});
         $('svg').css({'left': -this.mapPane.left,
-                      'top': -this.mapPane.top,
-                      'width': this.frame.width,
-                      'height': this.frame.height});
-
-        this.draw();
+                      'top': -this.mapPane.top});
     }
 
     draw(duration) {
@@ -147,13 +138,9 @@ class GridView extends View {
         // reposition svg canvas and send to back
         $('#svgDiv').css({'z-index': 0,
                           'left': 0,
-                          'top': 0,
-                          'width': this.frame.width,
-                          'height': this.frame.height});
+                          'top': 0});
         $('svg').css({'left': 0,
-                      'top': 0,
-                      'width': this.frame.width,
-                      'height': this.frame.height});
+                      'top': 0});
 
         this.database.devices.each(function(dev) {
             dev.signals.each(function(sig) {

--- a/js/views/HiveView.js
+++ b/js/views/HiveView.js
@@ -33,10 +33,7 @@ class HiveView extends View {
         this.resize();
     }
 
-    resize(newFrame, duration) {
-        if (newFrame)
-            this.frame = newFrame;
-
+    _resize(duration) {
         this.mapPane.left = 50;
         this.mapPane.width = this.frame.width - 100;
         this.mapPane.top = 50;

--- a/js/views/ListView.js
+++ b/js/views/ListView.js
@@ -61,10 +61,7 @@ class ListView extends View {
         this.resize(null, 1000);
     }
 
-    resize(newFrame, duration) {
-        if (newFrame)
-            this.frame = newFrame;
-
+    _resize(duration) {
         let self = this;
         this.tables.left.adjust(0, 0, this.frame.width * 0.4, this.frame.height, 0,
                                 duration);
@@ -76,7 +73,6 @@ class ListView extends View {
         this.mapPane.height = this.frame.height;
         this.mapPane.cx = this.frame.width * 0.5;
         this.mapPane.cy = this.frame.height * 0.5;
-        this.draw();
     }
 
     draw(duration) {

--- a/js/views/ParallelView.js
+++ b/js/views/ParallelView.js
@@ -23,10 +23,7 @@ class ParallelView extends View {
         this.resize();
     }
 
-    resize(newFrame, duration) {
-        if (newFrame)
-            this.frame = newFrame;
-
+    _resize(duration) {
         this.mapPane.left = 50;
         this.mapPane.width = this.frame.width - 100;
         this.mapPane.top = 50;

--- a/js/views/View.js
+++ b/js/views/View.js
@@ -76,10 +76,17 @@ class View {
         });
     }
 
-    resize(newFrame) {
+    // Subclasses should override the behavior of _resize rather than this one
+    resize(newFrame, duration) {
         if (newFrame)
             this.frame = newFrame;
+        this._resize(duration);
+        this.canvas.setViewBox(0, 0, this.frame.width, this.frame.height, false);
+        this.draw(duration);
+    }
 
+    // Define subclass specific resizing related tasks
+    _resize() {
         this.mapPane = {'left': this.frame.left,
                         'top': this.frame.top,
                         'width': this.frame.width,
@@ -88,8 +95,6 @@ class View {
                         'cy': this.frame.height * 0.5};
 
         this.origin = [this.mapPane.cx, this.mapPane.cy];
-
-        this.draw(0);
     }
 
     updateDevices(func) {


### PR DESCRIPTION
Signal Table
- Modified signal tables so that they always resize the scroller element even if an inner width and height are not specified
- Also removed the * 0.33 modifier on the duration which seems unnecessary and would appear to make the meaning of the duration argument to adjust() a bit misleading

All views
- changed resize() to a private method that subclasses should override, _resize(), so that the original resize() method can perform tasks common to all views, such as replacing the old frame with a new one if it is given, adjusting the view box of the canvas, and re- drawing.
- on that note, all views will now correctly adjust the view box of the canvas to fit the new window size

Chord view
- moved the logic for calculating path start and stop points into the drawDevice() method; previously it was calculated once during updateDevices(), which meant that the points would not be updated when the window was resized. 

Grid view
- moved the initial definition of left and right expand width to a spot where they will actually come into effect instead of being immediately overwritten by the call to update()
- removed the css adjustment of height and width which is redundant with setting the view box in View.resize()

