### PR TITLE
Reduce use of $('#container') events for global commands

### DIFF
--- a/html/webmapper.html
+++ b/html/webmapper.html
@@ -13,6 +13,7 @@
 <script type="text/javascript" src="js/util.js"></script>
 <script type="text/javascript" src="js/command.js"></script>
 <script type="text/javascript" src="js/Database.js"></script>
+<script type="text/javascript" src="js/Mapper.js"></script>
 
 <!-- View includes -->
 <script type="text/javascript" src="js/ViewManager.js"></script>

--- a/js/Database.js
+++ b/js/Database.js
@@ -750,7 +750,7 @@ function MapperDatabase() {
                     if (!dstsig)
                         return;
                     console.log('  Creating map:', srcsig.key, '->', dstsig.key);
-                    $('#container').trigger('map', [srcsig.key, dstsig.key, map]);
+                    mapper.map(srcsig.key, dstsig.key, map);
                 });
             });
         }

--- a/js/File.js
+++ b/js/File.js
@@ -211,7 +211,7 @@ class File {
             }
             src = src.join('/');
             dst = dst.join('/');
-            $('#container').trigger('map', [src, dst, map]);
+            mapper.map(src, dst, map);
         }
     }
 }

--- a/js/MapProperties.js
+++ b/js/MapProperties.js
@@ -68,7 +68,7 @@ class MapProperties {
         var self = this;
 
         $('#networkSelection').on('change', function(e) {
-            $(this.container).trigger("selectNetwork", e.currentTarget.value);
+            command.send("select_network", e.currentTarget.value);
         });
 
         //The expression and range input handlers
@@ -353,7 +353,7 @@ class MapProperties {
             msg['dst'] = map['dst'].key;
 
             // send the command, should receive a /mapped message after.
-            container.trigger("setMap", [msg]);
+            command.send("set_map", msg);
         });
     }
 

--- a/js/ViewManager.js
+++ b/js/ViewManager.js
@@ -292,7 +292,7 @@ class ViewManager
                     self.database.maps.each(function(map) {
                         if (map.selected)
                         {
-                            $('#container').trigger('unmap', [map.src.key, map.dst.key]);
+                            mapper.unmap(map.src.key, map.dst.key);
                             self.tooltip.hide();
                         }
                     });

--- a/js/main.js
+++ b/js/main.js
@@ -234,20 +234,6 @@ function initViewCommands()
         }
         wheeling = true;
     }, {passive: false});
-
-    // map command
-    // src = "devicename/signalname"
-    // dst = "devicename/signalname"
-    $("#container").on("map", function(e, src, dst, args) {
-        command.send('map', [src, dst, args]);
-    });
-
-    // unmap command
-    // src = "devicename/signalname"
-    // dst = "devicename/signalname"
-    $("#container").on("unmap", function(e, src, dst) {
-        command.send('unmap', [src, dst]);
-    });
 }
 
 // allows anyone to call updateMapProperties by triggering an event on #container

--- a/js/main.js
+++ b/js/main.js
@@ -207,14 +207,6 @@ function initViewCommands()
         }
     });
 
-    $('#container').on('updateView', function(e) {
-        viewManager.draw(0);
-    });
-
-    $('#container').on('scrolll', function(e) {
-        viewManager.draw(0);
-    });
-
     let wheeling = false;
     let pageX, pageY, deltaX, deltaY, zooming;
     document.addEventListener('wheel', function(e) {
@@ -243,35 +235,6 @@ function initViewCommands()
         wheeling = true;
     }, {passive: false});
 
-    // from list view
-    // requests links and maps from the selected device (tab)
-    $("#container").on("tab", function(e, tab){
-        if (tab != 'All Devices') {
-            // retrieve linked destination devices
-            database.links.each(function(link) {
-                if (tab == link.src)
-                    command.send('subscribe', link.dst);
-                else if (tab == link.dst)
-                    command.send('subscribe', link.src);
-            });
-            command.send('subscribe', tab);
-        }
-    });
-
-    // link command
-    // src = "devicename"
-    // dst = "devicename"
-    $("#container").on("link", function(e, src, dst) {
-        database.links.add({ 'src' : src, 'dst' : dst, 'num_maps': [0, 0] });
-    });
-
-    // unlink command
-    // src = "devicename"
-    // dst = "devicename"
-    $("#container").on("unlink", function(e, src, dst) {
-        database.links.remove(src, dst);
-    });
-
     // map command
     // src = "devicename/signalname"
     // dst = "devicename/signalname"
@@ -295,13 +258,6 @@ function initViewCommands()
     $("#container").on("updateMapPropertiesFor", function(e, key) {
         mapProperties.updateMapPropertiesFor(key);
     });
-
-    // asks the view for the save button link (based on the active device)
-    // currently implemented in List view only
-    $("#container").on("updateSaveLocation", function(e) {
-        mapProperties.updateSaveLocation(viewManager.get_save_location());
-    });
-
 }
 
 function initMapPropertiesCommands()
@@ -309,17 +265,9 @@ function initMapPropertiesCommands()
     $("#TopMenuWrapper").on("setMap", function(e, args) {
         command.send('set_map', args);
     });
-    $("#TopMenuWrapper").on("refreshAll", function(e) {
-        refresh_all();
-    });
     $("#TopMenuWrapper").on("selectNetwork", function(e, network) {
         command.send('select_network', network);
     });
-}
-
-function refresh_all() {
-    database.clearAll();
-    command.send('refresh');
 }
 
 function select_obj(obj) {

--- a/js/main.js
+++ b/js/main.js
@@ -248,7 +248,10 @@ function initViewCommands()
     $("#container").on("unmap", function(e, src, dst) {
         command.send('unmap', [src, dst]);
     });
+}
 
+// allows anyone to call updateMapProperties by triggering an event on #container
+function initMapPropertiesCommands() {
     // asks the view for the selected maps and updates the edit bar
     $("#container").on("updateMapProperties", function(e) {
         mapProperties.updateMapProperties();
@@ -257,16 +260,6 @@ function initViewCommands()
     // updated the properties for a specific map
     $("#container").on("updateMapPropertiesFor", function(e, key) {
         mapProperties.updateMapPropertiesFor(key);
-    });
-}
-
-function initMapPropertiesCommands()
-{
-    $("#TopMenuWrapper").on("setMap", function(e, args) {
-        command.send('set_map', args);
-    });
-    $("#TopMenuWrapper").on("selectNetwork", function(e, network) {
-        command.send('select_network', network);
     });
 }
 

--- a/js/mapper.js
+++ b/js/mapper.js
@@ -1,0 +1,22 @@
+//++++++++++++++++++++++++++++++++++++++//
+//            Mapper Class              //
+//++++++++++++++++++++++++++++++++++++++//
+
+// This class provides the functionality for creating and removing maps
+
+class Mapper
+{
+    constructor() {}
+
+    map(srckey, dstkey, props)
+    {
+        command.send('map', [srckey, dstkey, props])
+    }
+
+    unmap(srckey, dstkey)
+    {
+        command.send('unmap', [srckey, dstkey]);
+    }
+}
+
+var mapper = new Mapper(); // make global instance

--- a/js/views/CanvasView.js
+++ b/js/views/CanvasView.js
@@ -112,8 +112,7 @@ class CanvasView extends View {
         sig.view.unmouseup();
         sig.view.mouseup(function() {
             if (self.draggingFrom && self.snappingTo) {
-                $('#container').trigger('map', [self.draggingFrom.key,
-                                                self.snappingTo.key]);
+                mapper.map(self.draggingFrom.key, self.snappingTo.key);
                 if (self.newMap) {
                     self.newMap.remove();
                     self.newMap = null;

--- a/js/views/ConsoleView.js
+++ b/js/views/ConsoleView.js
@@ -52,7 +52,7 @@ class ConsoleView extends View {
                     switch (command[0]) {
                         case 'map':
                             if (command.length == 3)
-                                $('#container').trigger('map', [command[1], command[2]]);
+                                mapper.map(command[1], command[2]);
                             else
                                 this.echo('map: wrong number of arguments');
                             break;
@@ -62,12 +62,12 @@ class ConsoleView extends View {
                                 let index = 0;
                                 self.database.maps.each(function(map) {
                                     if (++index == command[1]) {
-                                        $('#container').trigger('unmap', [map.src.key, map.dst.key]);
+                                        mapper.unmap(map.src.key, map.dst.key);
                                     }
                                 });
                             }
                             else if (command.length == 3)
-                                $('#container').trigger('unmap', [command[1], command[2]]);
+                                mapper.unmap(command[1], command[2]);
                             else
                                 this.echo('unmap: wrong number of arguments');
                             break;

--- a/js/views/View.js
+++ b/js/views/View.js
@@ -325,8 +325,7 @@ class View {
         let self = this;
         sig.view.mouseup(function() {
             if (self.draggingFrom && self.snappingTo)
-                $('#container').trigger('map', [self.draggingFrom.key,
-                                                self.snappingTo.key]);
+                mapper.map(self.draggingFrom.key, self.snappingTo.key);
         });
         sig.view.undrag();
         sig.view.drag(
@@ -756,7 +755,7 @@ class View {
                     $(document).off('.drawing');
                     $('svg, .displayTable tbody tr').off('.drawing');
                     if (!self.escaped && dst && dst.id) {
-                        $('#container').trigger('map', [src.id, dst.id]);
+                        mapper.map(src.id, dst.id);
                         self.database.maps.add({'src': self.database.find_signal(src.id),
                                                 'dst': self.database.find_signal(dst.id),
                                                 'key': src.id + '->' + dst.id,


### PR DESCRIPTION
A lot of these events are not used anywhere, so they were removed. Others (setMap) can just call command.send(whatever) directly since command is a global var anyways. Map and unmap I moved into a global var mapper class, since these are likely to require some additional logic as convergent mapping is implemented. The events which call mapProperties methods are skipped for now.