### PR TITLE
Odd bug fixes to let devices and signals show up

### DIFF
--- a/libmapper.py
+++ b/libmapper.py
@@ -554,7 +554,7 @@ class Object:
                                                byref(_type), byref(_val), byref(_pub))
         else:
             return None
-        if prop == 0 or prop == 0x0200:
+        if prop == 0 or prop == 0x02000:
             return None
         prop = Property(prop)
 

--- a/webmapper.py
+++ b/webmapper.py
@@ -83,7 +83,7 @@ def sig_props(sig):
     del props['is_local']
     del props['id']
     props['direction'] = props['direction'].name
-    props['steal'] = props['steal'].name
+    props['steal'] = props['steal']
     props['type'] = props['type'].name
 #    print(props)
     return props


### PR DESCRIPTION
Not sure if this is just me, but I found some weird bugs that were preventing devices and signals from showing up in webmapper. Let me know if any of the assumed fixes aren't correct.

Error 1:
`File "C:\Users\brady\Documents\GitHub\McGill\webmapper\libmapper.py", line 559, in get_property
    prop = Property(prop)
  File "C:\Users\brady\anaconda3\lib\enum.py", line 309, in __call__
    return cls.__new__(cls, value)
  File "C:\Users\brady\anaconda3\lib\enum.py", line 600, in __new__
    raise exc
  File "C:\Users\brady\anaconda3\lib\enum.py", line 584, in __new__
    result = cls._missing_(value)
  File "C:\Users\brady\anaconda3\lib\enum.py", line 613, in _missing_
    raise ValueError("%r is not a valid %s" % (value, cls.__name__))
ValueError: 8192 is not a valid Property`

Fix: Change 0x200 on line 557 of libmapper.py to what I assume it was meant to be: 0x2000

Error 2:
`File ".\webmapper.py", line 86, in sig_props
    props['steal'] = props['steal'].name
AttributeError: 'int' object has no attribute 'name'`

Fix: remove .name from line 86, let it use the int property (MPR_PROP_STEAL_MODE)