### PR TITLE
Fix macOS packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,13 @@ jobs:
     - name: build standalone
       run:
         pyinstaller webmapper.spec
+    - name: cleanup build
+      run:
+        rm -frv dist/webmapper
     - uses: actions/upload-artifact@v4
       with:
         name: webmapper-macosx-standalone
-        path: dist/webmapper
-
+        path: dist/
   Windows-Latest:
     runs-on: windows-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ By default webmapper will open a browser window when it is launched, but there m
 python3 webmapper.py --no-browser --stay-alive
 ~~~
 
-## To build a standalone application for macOS:
+## To build a standalone application:
 
 ~~~
-python3 setup.py py2app
+pip3 install -r requirements.txt
+pip3 install pyinstaller
+pyinstaller webmapper.spec
 ~~~
 
 ---

--- a/html/webmapper_help.html
+++ b/html/webmapper_help.html
@@ -538,10 +538,12 @@ pre.line-numbers > code {
 
 <p>If the browser doesn&#39;t open, open it manually and type &quot;localhost:#####&quot; into the address bar, where ##### is the same string of numbers displayed in the terminal</p>
 
-<h3 id="toc_4">To build standalone application:</h3>
+<h3 id="toc_4">To build a standalone application:</h3>
 
 <ol>
-<li>$ python setup.py py2app</li>
+<li>$ pip3 install -r requirements.txt</li>
+<li>$ pip3 install pyinstaller</li>
+<li>$ pyinstaller webmapper.spec</li>
 </ol>
 
 <h3 id="toc_5">Saving and loading:</h3>

--- a/webmapper.spec
+++ b/webmapper.spec
@@ -74,6 +74,10 @@ coll = COLLECT(
 )
 # Build a .app if on OS X
 if sys.platform == 'darwin':
-   app = BUNDLE(exe,
-                name='webmapper.app',
-                icon=None)
+    app = BUNDLE(
+        coll, # instead of exe otherwise dependencies are not bundled
+        name='webmapper.app',
+        icon='images/libmapper.icns',
+        bundle_identifier=None,
+        version=libmapper.__version__, # until a webmapper version is defined
+)


### PR DESCRIPTION
## Related

#10 #25

## Changelog

- [x] Fix app bundle internal dependencies (bundle `col` instead of `exe`)
- [x] Restore app bundle icon
- [x] Only upload app bundle (delete `dist/webmapper/webmapper` containing a binary plus `_internal` folder, list removed files for debug)
- [x] Specify version (for now libmapper's) 
- [x] Update documentation